### PR TITLE
replace namespaces in soaprequests using string-replace

### DIFF
--- a/CORESubscriber/Program.cs
+++ b/CORESubscriber/Program.cs
@@ -93,7 +93,7 @@ namespace CORESubscriber
                 if (Dataset.ReadVariables(subscribed))
                     if (!GetLastIndex.Run()) continue;
 
-                if(string.IsNullOrEmpty(Dataset.Version)) OrderChangelog.Run();
+                if(Provider.GeosynchronizationNamespace == XmlNamespaces.Geosynchronization11) OrderChangelog.Run();
                 else OrderChangelog2.Run();
 
                 GetChangelogStatus.Run();

--- a/CORESubscriber/SoapAction/SoapRequest.cs
+++ b/CORESubscriber/SoapAction/SoapRequest.cs
@@ -12,9 +12,12 @@ namespace CORESubscriber.SoapAction
     {
         public static XDocument GetSoapContentByAction(string action)
         {
-            var soapContent = XDocument.Parse(File.ReadAllText("Queries/" + action + ".xml"));
+            var actionText = File.ReadAllText("Queries/" + action + ".xml");
 
-            soapContent.Root?.SetAttributeValue(XNamespace.Xmlns + "prod", Provider.GeosynchronizationNamespace.NamespaceName);
+            actionText = actionText.Replace(XmlNamespaces.Geosynchronization.NamespaceName,
+                Provider.GeosynchronizationNamespace.NamespaceName);
+
+            var soapContent = XDocument.Parse(actionText);
 
             return soapContent;
         }


### PR DESCRIPTION
check provider geosync-namespace to determine orderchangelog-method to use